### PR TITLE
Feat/118706163

### DIFF
--- a/router/index.js
+++ b/router/index.js
@@ -1,4 +1,4 @@
 module.exports = function(app) {
 	require('./routes/users')(app);
-	// require('./routes/items')(app);
+	require('./routes/items')(app);
 };

--- a/router/routes/items.js
+++ b/router/routes/items.js
@@ -1,4 +1,4 @@
-// var Item 		= require('../../models/item');
+var Item 		= require('../../models/item');
 var jwt 		= require('jsonwebtoken');
 var isAuthenticated = require('./../util').isAuthenticated
 

--- a/router/util.js
+++ b/router/util.js
@@ -4,7 +4,7 @@ var app			= require('express')();
 module.exports = {
 	isAuthenticated: function(req, res, next) {
 		
-		var token = req.body.token || req.param('token') || req.headers['x-access-token'];
+		var token = req.body.token || req.params.token || req.headers['x-access-token'];
 
 		if (!token) {
 			return res.status(403).send({ 

--- a/spec/controllers/test.js
+++ b/spec/controllers/test.js
@@ -21,7 +21,7 @@ describe('CONTROLLERS', function() {
 				.expect(200)
 				.end(function (err) {
 					if (err) {
-						return done(err);
+						return done.fail(err);
 					}
 					done();
 				});
@@ -40,7 +40,7 @@ describe('CONTROLLERS', function() {
 				.expect(500)
 				.end(function (err) {
 					if (err) {
-						return done(err);
+						return done.fail(err);
 					}
 					done();
 				});
@@ -56,7 +56,7 @@ describe('CONTROLLERS', function() {
 				.expect(500)
 				.end(function (err) {
 					if (err) {
-						return done(err);
+						return done.fail(err);
 					}
 					done();
 				});
@@ -72,7 +72,7 @@ describe('CONTROLLERS', function() {
 				.expect(500)
 				.end(function (err) {
 					if (err) {
-						return done(err);
+						return done.fail(err);
 					}
 					done();
 				});
@@ -88,7 +88,7 @@ describe('CONTROLLERS', function() {
 				.expect(500)
 				.end(function (err) {
 					if (err) {
-						return done(err);
+						return done.fail(err);
 					}
 					done();
 				});
@@ -104,7 +104,7 @@ describe('CONTROLLERS', function() {
 				.expect(200)
 				.end(function (err, res) {
 					if (err) {
-						return done(err);
+						return done.fail(err);
 					}
 					token = res.body.token;
 					done();
@@ -122,7 +122,7 @@ describe('CONTROLLERS', function() {
 				.expect(200)
 				.end(function (err) {
 					if (err) {
-						return done(err);
+						return done.fail(err);
 					}
 					done();
 				});
@@ -142,7 +142,7 @@ describe('CONTROLLERS', function() {
 				.expect(200)
 				.end(function (err) {
 					if (err) {
-						return done(err);
+						return done.fail(err);
 					}
 					done();
 				});

--- a/spec/controllers/test.js
+++ b/spec/controllers/test.js
@@ -155,12 +155,14 @@ describe('CONTROLLERS', function() {
 			it('returns a 200 OK status code', function(done) {
 				request(app)
 				.get(baseUrl + '/items')
+				.set('x-access-token', token)
 				.set('Accept', 'application/json')
 				.expect(200)
 				.end(function(err, res) {
 					if (err) {
-						return done(err);
+						return done.fail(err);
 					}
+					
 					done();
 				})
 			});

--- a/spec/controllers/test.js
+++ b/spec/controllers/test.js
@@ -149,4 +149,21 @@ describe('CONTROLLERS', function() {
 			});
 		});
 	});
+
+	describe('/items/', function() {
+		describe('GET', function() {
+			it('returns a 200 OK status code', function(done) {
+				request(app)
+				.get(baseUrl + '/items')
+				.set('Accept', 'application/json')
+				.expect(200)
+				.end(function(err, res) {
+					if (err) {
+						return done(err);
+					}
+					done();
+				})
+			});
+		});
+	});
 });


### PR DESCRIPTION
Adds a super basic Item model and endpoints. Note how tests are written. Apparently Jasmine breaks supertests' `expect`, so calling `done.fail` instead of just `done` is the workaround.